### PR TITLE
Add optional SexyAppFramework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # fishsong
 An attempt at reverse engineering Insaniquarium's fishsong format. Started with trying to do it just from the file format itsself and educated guesses, then went to using Ghidra but couldn't locate the logic for note duration parsing. 
 
-A lot of help from LLMs to put together the bits and pieces into something that should theoretically work.  
+A lot of help from LLMs to put together the bits and pieces into something that should theoretically work.
+
+## SexyAppFramework Integration
+
+This project can be built with PopCap's SexyAppFramework. Define `USE_SEXYAPP`
+and provide the framework headers and libraries when compiling. When enabled,
+file I/O uses `Sexy::SexyAppBase::ReadBufferFromFile` and logging goes through
+`OutputDebug`.


### PR DESCRIPTION
## Summary
- integrate optional SexyAppFramework support
- replace std file IO and logging with equivalents when `USE_SEXYAPP` is defined
- document integration in README

## Testing
- `g++ -std=c++17 -c Fishsong.cpp`
- `g++ -std=c++17 -DUSE_SEXYAPP -c Fishsong.cpp` *(fails: SexyAppFramework headers missing)*

